### PR TITLE
Added parser arg for concepts from text file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 # MISC
 .vscode/settings.json
 .gitignore
+.idea

--- a/fathomnet/scripts/fathomnet_generate.py
+++ b/fathomnet/scripts/fathomnet_generate.py
@@ -277,7 +277,7 @@ def parse_args() -> Arguments:
     # Parse list of concepts
     if args.concepts:
         concepts = args.concepts
-    elif args.concepts_list:
+    elif args.concepts_file:
         if os.path.isfile(args.concepts_file):
             with open(args.concepts_file, 'r') as ff:
                 concepts = list(ff)

--- a/fathomnet/scripts/fathomnet_generate.py
+++ b/fathomnet/scripts/fathomnet_generate.py
@@ -278,8 +278,8 @@ def parse_args() -> Arguments:
     if args.concepts:
         concepts = args.concepts
     elif args.concepts_list:
-        if os.path.isfile(args.concepts_list):
-            with open(args.concepts_list, 'r') as ff:
+        if os.path.isfile(args.concepts_file):
+            with open(args.concepts_file, 'r') as ff:
                 concepts = list(ff)
                 ff.close()
             concepts = [line.strip() for line in concepts]  # remove string format

--- a/fathomnet/scripts/fathomnet_generate.py
+++ b/fathomnet/scripts/fathomnet_generate.py
@@ -239,8 +239,9 @@ def parse_args() -> Arguments:
     valid_dataset_formats = ['voc', 'coco']
     
     parser.add_argument('-v', action='count', default=0, help='Increase verbosity')
-    parser.add_argument('-c', '--concepts', dest='concepts', type=comma_list, help='Comma-separated list of concepts to include')
     parser.add_argument('-t', '--taxa', dest='taxa', type=str, help='Taxonomy provider (to include descendants). Options: {}'.format(', '.join(valid_taxa_providers)))
+    parser.add_argument('-c', '--concepts', dest='concepts', type=comma_list, help='Comma-separated list of concepts to include')
+    parser.add_argument('--concept-file', dest='concepts_file', type=str, help='File containing comma-separated list of concepts to include')
     parser.add_argument('--contributor-email', dest='contributor_email', type=str, help='Contributor email')
     parser.add_argument('--start', dest='start_timestamp', type=datetime.datetime.fromisoformat, help='Start timestamp (formatted as ISO-8601)')
     parser.add_argument('--end', dest='end_timestamp', type=datetime.datetime.fromisoformat, help='End timestamp (formatted as ISO-8601)')
@@ -260,7 +261,7 @@ def parse_args() -> Arguments:
     count_or_output = parser.add_mutually_exclusive_group(required=True)
     count_or_output.add_argument('--count', dest='count', action='store_true', help='Count images and bounding boxes instead of generating a dataset')
     count_or_output.add_argument('-o', '--output', dest='output', type=str, help='Output directory')
-    
+
     # Parse arguments
     args = parser.parse_args()
     
@@ -274,7 +275,15 @@ def parse_args() -> Arguments:
     logging.basicConfig(level=level)
     
     # Parse list of concepts
-    concepts = args.concepts
+    if args.concepts:
+        concepts = args.concepts
+    elif args.concepts_list:
+        if os.path.isfile(args.concepts_list):
+            with open(args.concepts_list, 'r') as ff:
+                concepts = list(ff)
+                ff.close()
+            concepts = [line.strip() for line in concepts]  # remove string format
+
     if not concepts:
         parser.error('No concepts specified')
     

--- a/fathomnet/scripts/fathomnet_generate.py
+++ b/fathomnet/scripts/fathomnet_generate.py
@@ -241,7 +241,7 @@ def parse_args() -> Arguments:
     parser.add_argument('-v', action='count', default=0, help='Increase verbosity')
     parser.add_argument('-t', '--taxa', dest='taxa', type=str, help='Taxonomy provider (to include descendants). Options: {}'.format(', '.join(valid_taxa_providers)))
     parser.add_argument('-c', '--concepts', dest='concepts', type=comma_list, help='Comma-separated list of concepts to include')
-    parser.add_argument('--concept-file', dest='concepts_file', type=str, help='File containing comma-separated list of concepts to include')
+    parser.add_argument('--concepts-file', dest='concepts_file', type=str, help='File containing comma-separated list of concepts to include')
     parser.add_argument('--contributor-email', dest='contributor_email', type=str, help='Contributor email')
     parser.add_argument('--start', dest='start_timestamp', type=datetime.datetime.fromisoformat, help='Start timestamp (formatted as ISO-8601)')
     parser.add_argument('--end', dest='end_timestamp', type=datetime.datetime.fromisoformat, help='End timestamp (formatted as ISO-8601)')


### PR DESCRIPTION
Added `--concepts-file` as parser arg to read from text file list of concepts. Tested with a bunch of Sebastes in the attached file and the following command:

`fathomnet-generate --count --concepts-file /Users/eorenstein/Desktop/benthic_concepts_test.txt --start 2018-10-04 --end 2019-12-31 -v`


[benthic_concepts_test.txt](https://github.com/fathomnet/fathomnet-py/files/7646549/benthic_concepts_test.txt)
  