### PR TITLE
reordered operations in python notebook

### DIFF
--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -72,7 +72,32 @@
         "id": "-uNeHCauXyvC"
       },
       "source": [
-        "First, we'll install a few packages via pip:"
+        "Note: this notebook assumes you are running from a colab environment. If this is not the case you may have to manually install a few packages that are pre-installed in colab such as numpy and pandas. \n",
+        "\n",
+        "First, import the auxiliary modules we need for part 1:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import ipywidgets as widgets                      # Provides embedded widgets\n",
+        "import ipyleaflet                                 # Provides map widgets\n",
+        "import requests                                   # Manages HTTP requests\n",
+        "import numpy as np                                # Facilitates array/matrix operations\n",
+        "import plotly.express as px                       # Generates nice plots\n",
+        "import random                                     # Generates pseudo-random numbers\n",
+        "from PIL import Image, ImageFont, ImageDraw       # Facilitates image operations\n",
+        "from io import BytesIO                            # Interfaces byte data"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Next, we'll install a few packages via pip:"
       ]
     },
     {
@@ -84,33 +109,6 @@
       "outputs": [],
       "source": [
         "!pip install -q -U fathomnet ipyleaflet"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NfilAbptX2LU"
-      },
-      "source": [
-        "and import the auxiliary modules we need for part 1:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "QpcYIXG-sofq"
-      },
-      "outputs": [],
-      "source": [
-        "import ipywidgets as widgets                      # Provides embedded widgets\n",
-        "import ipyleaflet                                 # Provides map widgets\n",
-        "import requests                                   # Manages HTTP requests\n",
-        "import numpy as np                                # Facilitates array/matrix operations\n",
-        "import plotly.express as px                       # Generates nice plots\n",
-        "import random                                     # Generates pseudo-random numbers\n",
-        "from PIL import Image, ImageFont, ImageDraw       # Facilitates image operations\n",
-        "from io import BytesIO                            # Interfaces byte data"
       ]
     },
     {


### PR DESCRIPTION
Switched order of imports to avoid ipyleaflet error with FathomNet install and added explanation on running outside of colab.