### PR TITLE
fix: route worms taxa provider through Fast WoRMS to avoid 500s

### DIFF
--- a/src/fathomnet/api/taxa.py
+++ b/src/fathomnet/api/taxa.py
@@ -1,13 +1,32 @@
 # taxa.py (fathomnet-py)
-from typing import List
+from typing import Iterator, List
 from urllib.parse import quote
 
 from fathomnet import dto
-from fathomnet.api import EndpointManager
+from fathomnet.api import EndpointManager, worms
 
 
 class Taxa(EndpointManager):
     PATH = "taxa"
+
+
+WORMS_PROVIDER_NAME = "worms"
+
+
+def _is_worms(provider_name: str) -> bool:
+    return provider_name.lower() == WORMS_PROVIDER_NAME
+
+
+def _to_taxa(node: dto.WormsNode) -> dto.Taxa:
+    """Narrow a WoRMS node to the name/rank pair the taxa endpoint returns."""
+    return dto.Taxa(name=node.name, rank=node.rank)
+
+
+def _walk(node: dto.WormsNode) -> Iterator[dto.WormsNode]:
+    """Yield a WoRMS node and all of its descendants, depth-first."""
+    yield node
+    for child in node.children or []:
+        yield from _walk(child)
 
 
 def list_taxa_providers() -> List[str]:
@@ -18,6 +37,9 @@ def list_taxa_providers() -> List[str]:
 
 def find_children(provider_name: str, concept: str) -> List[dto.Taxa]:
     """Find the taxonomic children for a concept according to a taxa provider."""
+    if _is_worms(provider_name):
+        return [_to_taxa(node) for node in worms.get_children(concept)]
+
     res_json = Taxa.get(
         "query/children/{}/{}".format(quote(provider_name), quote(concept))
     )
@@ -26,6 +48,9 @@ def find_children(provider_name: str, concept: str) -> List[dto.Taxa]:
 
 def find_parent(provider_name: str, concept: str) -> dto.Taxa:
     """Find the taxonomic parent for a concept according to a taxa provider."""
+    if _is_worms(provider_name):
+        return _to_taxa(worms.get_parent(concept))
+
     res_json = Taxa.get(
         "query/parent/{}/{}".format(quote(provider_name), quote(concept))
     )
@@ -34,5 +59,8 @@ def find_parent(provider_name: str, concept: str) -> dto.Taxa:
 
 def find_taxa(provider_name: str, concept: str) -> List[dto.Taxa]:
     """Get a list of all taxonomic descendants of a concept (including the concept itself) according to a taxa provider."""
+    if _is_worms(provider_name):
+        return [_to_taxa(node) for node in _walk(worms.get_descendants(concept))]
+
     res_json = Taxa.get("query/{}/{}".format(quote(provider_name), quote(concept)))
     return list(map(dto.Taxa.from_dict, res_json))

--- a/test/test_taxa.py
+++ b/test/test_taxa.py
@@ -30,3 +30,39 @@ class TestTaxaAPI(TestCase):
                 break
         else:
             self.fail()
+
+    def test_find_taxa_worms_species(self):
+        # Regression: issue #35, the taxa endpoint 500s for non-genus ranks
+        results = taxa.find_taxa("worms", "Mycteroperca microlepis")
+        self.assertIsNotNone(results)
+        self.assertIn("Mycteroperca microlepis", set(item.name for item in results))
+
+    def test_find_taxa_worms_family(self):
+        results = taxa.find_taxa("worms", "Serranidae")
+        self.assertIsNotNone(results)
+        names = set(item.name for item in results)
+        self.assertIn("Serranidae", names)
+        self.assertIn("Serranus", names)
+        self.assertIn("Centropristis striata", names)
+
+    def test_find_taxa_worms_genus(self):
+        results = taxa.find_taxa("worms", "Nanomia")
+        self.assertEqual(
+            sorted((item.name, item.rank) for item in results),
+            [
+                ("Nanomia", "Genus"),
+                ("Nanomia bijuga", "Species"),
+                ("Nanomia cara", "Species"),
+                ("Nanomia septata", "Species"),
+            ],
+        )
+
+    def test_find_children_worms(self):
+        children = taxa.find_children("worms", "Bathochordaeus")
+        self.assertIsNotNone(children)
+        self.assertIn("Bathochordaeus mcnutti", set(child.name for child in children))
+
+    def test_find_parent_worms(self):
+        parent = taxa.find_parent("worms", "Bathochordaeus mcnutti")
+        self.assertIsNotNone(parent)
+        self.assertEqual(parent.name, "Bathochordaeus")


### PR DESCRIPTION
The worms taxa provider returns a 500 error for any rank other than genus (species, family, etc.). This routes worms queries through the existing fathomnet.api.worms client instead, which handles every rank correctly. Other providers are unchanged.